### PR TITLE
feat: Implement text highlighting in PDF viewer for citations

### DIFF
--- a/src/components/CitationPreviewSidebar.tsx
+++ b/src/components/CitationPreviewSidebar.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, useCallback } from "react";
 import { Document, Page } from "react-pdf"; // Added pdfjs
 // Use the specific pdfjs-dist version that react-pdf depends on
 // Import the main library entry; worker set separately in PdfWorkerSetup.tsx
@@ -77,6 +77,22 @@ const CitationPreviewSidebar: React.FC<CitationPreviewSidebarProps> = ({
   console.log('📄 - pdfUrl length:', pdfUrl?.length || 0);
   console.log('📄 ===== PDF COMPONENT RENDER END =====');
 
+  const customTextRenderer = useCallback(
+    (textItem: { str: string; itemIndex: number }) => {
+      const { str } = textItem;
+      if (!previewData?.textToHighlight || !str) {
+        return str;
+      }
+
+      const { textToHighlight } = previewData;
+      const escapedHighlightText = textToHighlight.replace(/[.*+?^${}()|[\]\]/g, '\$&');
+      const regex = new RegExp(`(${escapedHighlightText})`, 'gi');
+
+      return str.replace(regex, (match) => `<mark>${match}</mark>`);
+    },
+    [previewData]
+  );
+
   return (
     <Sheet
       open={isOpen}
@@ -133,6 +149,7 @@ const CitationPreviewSidebar: React.FC<CitationPreviewSidebarProps> = ({
                   scale={1.0} // Adjust scale as needed, could be dynamic
                   renderAnnotationLayer={true}
                   renderTextLayer={true} // Important for text selection/highlighting
+                  customTextRenderer={customTextRenderer} // Add this prop
                   onRenderAnnotationLayerSuccess={() => console.log('📄 Annotation layer rendered successfully for page', pageNumber)}
                   onRenderAnnotationLayerError={(error: unknown) => {
                     const message = error instanceof Error ? error.message : String(error);

--- a/src/components/CitationPreviewSidebar.tsx
+++ b/src/components/CitationPreviewSidebar.tsx
@@ -85,7 +85,7 @@ const CitationPreviewSidebar: React.FC<CitationPreviewSidebarProps> = ({
       }
 
       const { textToHighlight } = previewData;
-      const escapedHighlightText = textToHighlight.replace(/[.*+?^${}()|[\]\]/g, '\$&');
+      const escapedHighlightText = textToHighlight.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
       const regex = new RegExp(`(${escapedHighlightText})`, 'gi');
 
       return str.replace(regex, (match) => `<mark>${match}</mark>`);


### PR DESCRIPTION
This commit introduces text highlighting in the PDF viewer sidebar. When you click on a citation link in the RAG chat, the corresponding text chunk is now highlighted in the rendered PDF.

Changes include:
- Modified `src/components/CitationPreviewSidebar.tsx` to:
  - Import `useCallback` from React.
  - Define a `customTextRenderer` function that uses the `textToHighlight` property from `previewData`. This function escapes the highlight text for safe use in a regular expression and then replaces all matching instances (case-insensitive) in the PDF's text layer items with the text wrapped in `<mark>` tags.
  - Pass the `customTextRenderer` function to the `customTextRenderer` prop of the `Page` component from `react-pdf`.
- Ensured that `renderTextLayer={true}` is set for the `Page` component, which is a prerequisite for `customTextRenderer` to function.